### PR TITLE
Ajoute le formulaire Mailchimp pour infolettre

### DIFF
--- a/layouts/partials/contact.html
+++ b/layouts/partials/contact.html
@@ -17,7 +17,7 @@
               <input type="email" value="" name="EMAIL" class="email" id="mce-EMAIL" placeholder="email address" required>
               <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
               <div style="position: absolute; left: -5000px;" aria-hidden="true"><input type="text" name="b_67c56a4224e79e980c9022db9_6e5f62b588" tabindex="-1" value=""></div>
-              <div class="clear"><input type="submit" value="Subscribe" name="subscribe" id="mc-embedded-subscribe" class="button"></div>
+              <div class="clear"><input type="submit" value="S'inscrire" name="subscribe" id="mc-embedded-subscribe" class="button"></div>
             </div>
           </form>
         </div>

--- a/layouts/partials/contact.html
+++ b/layouts/partials/contact.html
@@ -6,6 +6,24 @@
       <div class="col-xs-12">
         <h1>Contactez-nous</h1>
       </div>
+
+      <!-- Begin Mailchimp Signup Form -->
+      <div class="col-xs-12">
+        <h2>Infolettre</h2>
+        <div id="mc_embed_signup">
+          <form action="https://victimespesticidesquebec.us2.list-manage.com/subscribe/post?u=67c56a4224e79e980c9022db9&amp;id=6e5f62b588" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_blank" novalidate>
+            <div id="mc_embed_signup_scroll">
+              <label for="mce-EMAIL">Inscrivez-vous à notre infolettre:</label>
+              <input type="email" value="" name="EMAIL" class="email" id="mce-EMAIL" placeholder="email address" required>
+              <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
+              <div style="position: absolute; left: -5000px;" aria-hidden="true"><input type="text" name="b_67c56a4224e79e980c9022db9_6e5f62b588" tabindex="-1" value=""></div>
+              <div class="clear"><input type="submit" value="Subscribe" name="subscribe" id="mc-embedded-subscribe" class="button"></div>
+            </div>
+          </form>
+        </div>
+      </div>
+      <!-- End Mailchimp Signup form -->
+
       <div class="col-xs-12">
         <p>Vous avez une question ou un commentaire? N’hésitez pas, <br/>
         contactez-nous: <a href="mailto: info@victimespesticidesquebec.org">info@victimespesticidesquebec.org</a></p>
@@ -14,7 +32,7 @@
 
     <div class="row">
       <div class="col-xs-12">
-        <h2>Devenez membre</h1>
+        <h2>Devenez membre</h2>
       </div>
       <div class="col-xs-12">
         <p><em>Victimes des pesticides du Québec</em> a besoin de votre appui!</p>

--- a/layouts/partials/css.html
+++ b/layouts/partials/css.html
@@ -28,4 +28,13 @@
   .container {
     padding: 4rem 0;
   }
+
+  #mc-embedded-subscribe {
+    width: 25%;
+  }
+
+  #mc_embed_signup {
+    padding-bottom: 1em;
+  }
+
 </style>


### PR DESCRIPTION
Dans la section `Contact`.

Pour tester, clique sur le lien indiqué sur l'image: 
<img width="939" alt="Ajoute le formulaire Mailchimp pour infolettre by manumilou · Pull Request #7 · manumilou:victimes-pesticides 2020-09-25 17-46-03" src="https://user-images.githubusercontent.com/212768/94318691-10f5c000-ff57-11ea-92e6-99cf28317aa5.png">
